### PR TITLE
Fixing error in installation of opencv-python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN \
 	ffmpeg \ 
 	git
 
+RUN pip3 install --upgrade pip
 RUN pip3 intall numpy
 RUN pip3 install opencv-python
 RUN pip3 install requests


### PR DESCRIPTION
From opencv-python version 4.3.0, running this Dockerfile, causes following error:
     ModuleNotFoundError: No module named 'skbuild'

To avoid above error, added this modification.

For details, See opencv-python 4.4.0.40 (https://pypi.org/project/opencv-python/).
Error reason is as following:

Since opencv-python version 4.3.0.*, manylinux1 wheels were replaced by manylinux2014 wheels. If your pip is too old, it will try to use the new source distribution introduced in 4.3.0.38 to manually build OpenCV because it does not know how to install manylinux2014 wheels. However, source build will also fail because of too old pip because it does not understand build dependencies in pyproject.toml. To use the new manylinux2014 pre-built wheels (or to build from source), your pip version must be >= 19.3. Please upgrade pip with pip install --upgrade pip.